### PR TITLE
Change upload triggering mechanism

### DIFF
--- a/inventory_upload.py
+++ b/inventory_upload.py
@@ -20,8 +20,6 @@ import obmc.mapper
 import obmc.utils.dtree
 import obmc.utils.pathtree
 import dbus
-import dbus.mainloop.glib
-import gobject
 import os
 import subprocess
 import tempfile
@@ -83,67 +81,39 @@ def transform(path, o):
     return path, o
 
 
-class InventoryUpload(object):
-    def __init__(self, bus):
-        self.bus = bus
-        self.bus.add_signal_receiver(
-            self.state_handler,
-            dbus_interface='org.openbmc.Control',
-            signal_name='GotoSystemState')
-        self.bus.add_signal_receiver(
-            self.bus_handler,
-            dbus_interface=dbus.BUS_DAEMON_IFACE,
-            signal_name='NameOwnerChanged')
-
-    def bus_handler(self, name, old, new):
-        if name == 'org.openbmc.Inventory' and new:
-            self.upload()
-
-    def state_handler(self, state):
-        if state == 'HOST_POWERED_OFF':
-            self.upload()
-
-    def upload(self):
-        objs = obmc.utils.pathtree.PathTree()
-
-        mapper = obmc.mapper.Mapper(self.bus)
-        for path, props in \
-                mapper.enumerate_subtree(
-                    path='/org/openbmc/inventory/system').iteritems():
-            item = transform(path, props)
-            if item:
-                objs[item[0]] = item[1]
-
-        rpipe, wpipe = os.pipe()
-        rpipe = os.fdopen(rpipe, 'r')
-        wpipe = os.fdopen(wpipe, 'a')
-
-        wpipe.write('/dts-v1/;')
-        obmc.utils.dtree.dts_encode(objs.dumpd(), wpipe)
-        wpipe.close()
-        h, tmpfile = tempfile.mkstemp()
-        try:
-            wfile = os.fdopen(h, 'w')
-            subprocess.call(
-                ['dtc', '-f', '-O', 'dtb'],
-                stdin=rpipe,
-                stdout=wfile)
-            rpipe.close()
-            wfile.close()
-
-            print "Uploading inventory to PNOR in dtb format..."
-            subprocess.call(
-                ['pflash', '-f', '-e', '-p', tmpfile, '-P', 'BMC_INV'])
-        except:
-            os.remove(tmpfile)
-            raise
-
-        os.remove(tmpfile)
-
 if __name__ == '__main__':
-    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-    loop = gobject.MainLoop()
     bus = dbus.SystemBus()
-    uploader = InventoryUpload(bus)
+    objs = obmc.utils.pathtree.PathTree()
 
-    loop.run()
+    mapper = obmc.mapper.Mapper(bus)
+    for path, props in \
+            mapper.enumerate_subtree(
+                path='/org/openbmc/inventory/system').iteritems():
+        item = transform(path, props)
+        if item:
+            objs[item[0]] = item[1]
+
+    rpipe, wpipe = os.pipe()
+    rpipe = os.fdopen(rpipe, 'r')
+    wpipe = os.fdopen(wpipe, 'a')
+
+    wpipe.write('/dts-v1/;')
+    obmc.utils.dtree.dts_encode(objs.dumpd(), wpipe)
+    wpipe.close()
+    h, tmpfile = tempfile.mkstemp()
+    try:
+        wfile = os.fdopen(h, 'w')
+        subprocess.call(
+            ['dtc', '-O', 'dtb'],
+            stdin=rpipe,
+            stdout=wfile)
+        rpipe.close()
+        wfile.close()
+
+        print "Uploading inventory to PNOR in dtb format..."
+        subprocess.call(['pflash', '-f', '-e', '-p', tmpfile, '-P', 'BMC_INV'])
+    except:
+        os.remove(tmpfile)
+        raise
+
+    os.remove(tmpfile)


### PR DESCRIPTION
This reverts most of dbc81d6.  The previous triggering mechanism
did not prevent a user from powering the system on while the PNOR
is updated and vise versa.  The new mechanism just does the upload
prior to stating the host.

Signed-off-by: Brad Bishop bradleyb@fuzziesquirrel.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openpower-inventory-upload/4)

<!-- Reviewable:end -->
